### PR TITLE
Send the webdriver logs to a file rather than STDOUT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - npm run build
 
 before_script:
-  - npm run webdriver-start 2>&1 > /tmp/webdriver_output.txt &
+  - npm run webdriver-start > /tmp/webdriver_output.txt 2>&1 &
   - npm start 2>&1 &
   - sleep 5 # give server time to start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,12 @@ install:
   - npm run build
 
 before_script:
-  - npm run webdriver-start 2>&1 &
+  - npm run webdriver-start 2>&1 > /tmp/webdriver_output.txt &
   - npm start 2>&1 &
   - sleep 5 # give server time to start
 
 script:
   - gulp test
+  
+after_failure:
+  - cat /tmp/webdriver_output.txt


### PR DESCRIPTION
This keeps the Travis output clean instead of having all WebDriver logs in the middle. The WebDriver logs are displayed on failure.
